### PR TITLE
Downgrade sqlalchemy dependency to 1.4.27 to resolve conflict when in…

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,10 @@
 Release Notes
 =============
 
+v2.4.1
+------
+* Downgrade sqlalchemy dependency to 1.4.27 to resolve conflict when installing DKUtils in Google Composer.
+
 v2.4.0
 ------
 * Add get/add/delete/update kitchen staff/roles functions to DataKitchenClient.

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ sphinx-rtd-theme==0.4.3
 google-api-python-client==1.10.1
 google-auth-httplib2==0.0.4
 google-auth-oauthlib==0.4.2
-sqlalchemy==1.4.28
+sqlalchemy==1.4.27

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setuptools.setup(
         "google-api-python-client>=1.10.1",
         "google-auth-httplib2>=0.0.4",
         "google-auth-oauthlib>=0.4.2",
-        "sqlalchemy>=1.4.28",
+        "sqlalchemy>=1.4.27",
     ],
     tests_require=[
         'bumpversion>=0.5.3',


### PR DESCRIPTION
…stalling DKUtils in Google Composer.