### PR TITLE
Update monitor

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -4,6 +4,8 @@ Release Notes
 v2.9.0
 ------
 * OrderRunMonitor now uses the node's start_time for the event_timestamp (previously it used datetime.now())
+* OrderRunMonitor now publishes WARNING, ERROR, and CRITICAL log messages
+* OrderRunMonitor now publishes test results
 
 v2.8.0
 ------

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,10 @@
 Release Notes
 =============
 
+v2.9.0
+------
+* OrderRunMonitor now uses the node's start_time for the event_timestamp (previously it used datetime.now())
+
 v2.8.0
 ------
 * Added testing and docstrings to OrderRunMonitor class

--- a/ignored_secrets.txt
+++ b/ignored_secrets.txt
@@ -222,4 +222,5 @@ dkutils/datakitchen_api/vault.py,84,.*Vault URL \(default: https://vault2\.datak
 dkutils/decorators.py,16,.*original from: http://wiki\.python\.org/moin/PythonDecoratorLibrary#Retry.*
 dkutils/datakitchen_api/order_run_monitor.py,23,.*DEFAULT_HOST = 'https://dev-api\.datakitchen\.io'.*
 dkutils/datakitchen_api/order_run_monitor.py,145,.*URL of the Events Ingestion API \(default: https://dev-api\.datakitchen\.io'\)\..*
+dkutils/datakitchen_api/order_run_monitor.py,147,.*URL of the Events Ingestion API \(default: https://dev-api\.datakitchen\.io'\)\..*
 

--- a/ignored_secrets.txt
+++ b/ignored_secrets.txt
@@ -223,4 +223,7 @@ dkutils/decorators.py,16,.*original from: http://wiki\.python\.org/moin/PythonDe
 dkutils/datakitchen_api/order_run_monitor.py,23,.*DEFAULT_HOST = 'https://dev-api\.datakitchen\.io'.*
 dkutils/datakitchen_api/order_run_monitor.py,145,.*URL of the Events Ingestion API \(default: https://dev-api\.datakitchen\.io'\)\..*
 dkutils/datakitchen_api/order_run_monitor.py,147,.*URL of the Events Ingestion API \(default: https://dev-api\.datakitchen\.io'\)\..*
+dkutils/datakitchen_api/order_run_monitor.py,26,.*DEFAULT_HOST = 'https://dev-api\.datakitchen\.io'.*
+dkutils/datakitchen_api/order_run_monitor.py,42,.*ALLOWED_TEST_STATUS_TYPES = \['PASSED', 'FAILED', 'WARNING'\].*
+dkutils/datakitchen_api/order_run_monitor.py,202,.*URL of the Events Ingestion API \(default: https://dev-api\.datakitchen\.io'\)\..*
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dataclasses==0.6
-events_ingestion_client==0.0.5
+events_ingestion_client==0.0.6
 jira==2.0.0
 pandas==1.1.2
 paramiko==2.10.4

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
     python_requires='>=3.8',
     install_requires=[
         "dataclasses>=0.6",
-        "events_ingestion_client>=0.0.5",
+        "events_ingestion_client>=0.0.6",
         "jira>=2.0.0",
         "pandas>=1.1.2",
         "paramiko>=2.10.4",

--- a/tests/datakitchen_api/test_order_run_monitor.py
+++ b/tests/datakitchen_api/test_order_run_monitor.py
@@ -29,47 +29,95 @@ ORDER_RUN_DETAILS = {
         'nodes': {
             'Action_Node_Test': {
                 'status': 'DKNodeStatus_completed_production',
-                'start_time': 1660678738681
+                'start_time': 1660678738681,
+                'tests': {},
+                'actions': {
+                    'source': {
+                        'tests': {
+                            'Action_Node_Test': {
+                                'applies-to-keys': None,
+                                'metric': 'condition',
+                                'results': 'True '
+                                           'equal-to '
+                                           'condition=True',
+                                'status': 'Passed',
+                                'value': True
+                            }
+                        }
+                    }
+                }
             },
             'Condition': {
                 'status': 'DKNodeStatus_completed_production',
-                'start_time': 1660678738681
+                'start_time': 1660678738681,
+                'tests': {}
             },
             'Condition_False': {
                 'status': 'DKNodeStatus_Skipped',
-                'start_time': 1660678738681
+                'start_time': 1660678738681,
+                'tests': {}
             },
             'Condition_True': {
                 'status': 'DKNodeStatus_completed_production',
-                'start_time': 1660678738681
+                'start_time': 1660678738681,
+                'tests': {}
             },
             'DataMapper_Node_Test': {
                 'status': 'DKNodeStatus_completed_production',
-                'start_time': 1660678738681
+                'start_time': 1660678738681,
+                'tests': {}
             },
             'Fail_Node': {
                 'status': 'DKNodeStatus_production_error',
-                'start_time': 1660678738681
+                'start_time': 1660678738681,
+                'tests': {
+                    'Fail': {
+                        'applies-to-keys': [],
+                        'metric': 'condition == False',
+                        'results': 'True condition == False',
+                        'status': 'Failed',
+                        'value': True
+                    }
+                },
             },
             'Node_After_Fail': {
                 'status': 'DKNodeStatus_ready_for_production',
-                'start_time': 1660678738681
+                'start_time': 1660678738681,
+                'tests': {}
             },
             'Node_After_Sleep': {
                 'status': 'DKNodeStatus_completed_production',
-                'start_time': 1660678738681
+                'start_time': 1660678738681,
+                'tests': {}
             },
             'Order_Run_Monitor': {
                 'status': 'DKNodeStatus_completed_production',
-                'start_time': 1660678738681
+                'start_time': 1660678738681,
+                'tests': {}
             },
             'Quick_Node': {
                 'status': 'DKNodeStatus_completed_production',
-                'start_time': 1660678738681
+                'start_time': 1660678738681,
+                'tests': {}
             },
             'Sleep': {
                 'status': 'DKNodeStatus_completed_production',
-                'start_time': 1660678738681
+                'start_time': 1660678738681,
+                'tests': {},
+                'data_sinks': {
+                    's3_sink': {
+                        'tests': {
+                            'S3_Sink_Test': {
+                                'applies-to-keys': None,
+                                'metric': 'condition',
+                                'results': 'True '
+                                           'condition',
+                                'status': 'Passed',
+                                'value': True
+                            }
+                        }
+                    }
+                },
             }
         }
     }

--- a/tests/datakitchen_api/test_order_run_monitor.py
+++ b/tests/datakitchen_api/test_order_run_monitor.py
@@ -28,37 +28,48 @@ ORDER_RUN_DETAILS = {
     'summary': {
         'nodes': {
             'Action_Node_Test': {
-                'status': 'DKNodeStatus_completed_production'
+                'status': 'DKNodeStatus_completed_production',
+                'start_time': 1660678738681
             },
             'Condition': {
-                'status': 'DKNodeStatus_completed_production'
+                'status': 'DKNodeStatus_completed_production',
+                'start_time': 1660678738681
             },
             'Condition_False': {
-                'status': 'DKNodeStatus_Skipped'
+                'status': 'DKNodeStatus_Skipped',
+                'start_time': 1660678738681
             },
             'Condition_True': {
-                'status': 'DKNodeStatus_completed_production'
+                'status': 'DKNodeStatus_completed_production',
+                'start_time': 1660678738681
             },
             'DataMapper_Node_Test': {
-                'status': 'DKNodeStatus_completed_production'
+                'status': 'DKNodeStatus_completed_production',
+                'start_time': 1660678738681
             },
             'Fail_Node': {
-                'status': 'DKNodeStatus_production_error'
+                'status': 'DKNodeStatus_production_error',
+                'start_time': 1660678738681
             },
             'Node_After_Fail': {
-                'status': 'DKNodeStatus_ready_for_production'
+                'status': 'DKNodeStatus_ready_for_production',
+                'start_time': 1660678738681
             },
             'Node_After_Sleep': {
-                'status': 'DKNodeStatus_completed_production'
+                'status': 'DKNodeStatus_completed_production',
+                'start_time': 1660678738681
             },
             'Order_Run_Monitor': {
-                'status': 'DKNodeStatus_completed_production'
+                'status': 'DKNodeStatus_completed_production',
+                'start_time': 1660678738681
             },
             'Quick_Node': {
-                'status': 'DKNodeStatus_completed_production'
+                'status': 'DKNodeStatus_completed_production',
+                'start_time': 1660678738681
             },
             'Sleep': {
-                'status': 'DKNodeStatus_completed_production'
+                'status': 'DKNodeStatus_completed_production',
+                'start_time': 1660678738681
             }
         }
     }


### PR DESCRIPTION
- OrderRunMonitor now uses the node's start_time for the event_timestamp (previously it used datetime.now())
- OrderRunMonitor now publishes WARNING, ERROR, and CRITICAL log messages
- OrderRunMonitor now publishes test results