### PR TITLE
Update monitor

### DIFF
--- a/dkutils/datakitchen_api/kitchen.py
+++ b/dkutils/datakitchen_api/kitchen.py
@@ -40,6 +40,13 @@ class Kitchen:
         self._parent_name = None
 
     @property
+    def name(self) -> str:
+        """
+        Kitchen name
+        """
+        return self._name
+
+    @property
     def parent_name(self) -> str:
         """
         Parent kitchen name

--- a/dkutils/datakitchen_api/order_run_monitor.py
+++ b/dkutils/datakitchen_api/order_run_monitor.py
@@ -248,6 +248,13 @@ class OrderRunMonitor:
             URL of the Events Ingestion API (default: https://dev-api.datakitchen.io').
         """
         self._dk_client = dk_client
+
+        # Expected pipeline_name is <KITCHEN>.<RECIPE>.<VARIATION> - replace ingredient kitchen
+        # name with parent kitchen name to send ingredient events to the parent order run pipeline
+        kitchen = self._dk_client.get_kitchen()
+        if kitchen.is_ingredient() and kitchen.name in pipeline_name:
+            pipeline_name = pipeline_name.replace(kitchen.name, kitchen.parent_name)
+
         self._event_info_provider = EventInfoProvider.init(dk_client, pipeline_name, order_run_id)
         self._order_run_id = order_run_id
         self._nodes_to_ignore = nodes_to_ignore if nodes_to_ignore is not None else []

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -5,6 +5,7 @@ v2.11.0
 -------
 * Add order run external url to published events in the order run monitor
 * Order Run Monitor now handles ingredients by replacing the ingredient kitchen name in the pipeline_name with the parent kitchen name to associate events with the parent order run.
+* Update dependency events_ingestion_client to v0.0.8
 
 v2.10.0
 -------

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,11 @@
 Release Notes
 =============
 
+v2.11.0
+-------
+* Add order run external url to published events in the order run monitor
+* Order Run Monitor now handles ingredients by replacing the ingredient kitchen name in the pipeline_name with the parent kitchen name to associate events with the parent order run.
+
 v2.10.0
 -------
 * Nodes now always publish a STARTED task event in the OrderRunMonitor

--- a/ignored_secrets.txt
+++ b/ignored_secrets.txt
@@ -185,42 +185,43 @@ dkutils/datakitchen_api/datakitchen_client.py,1540,.*hierarchy of all files in a
 dkutils/datakitchen_api/datakitchen_client.py,1578,.*"url": "https://github\.com/api/v3/repos/DataKitchen\.\.\..*
 dkutils/datakitchen_api/datakitchen_client.py,1629,.*If the current user is not in the kitchen_staff.*
 dkutils/decorators.py,15,.*http://www\.saltycrane\.com/blog/2009/11/trying-out-retry-decorator-python/.*
-dkutils/datakitchen_api/kitchen.py,192,.*'Admin': \['admin@gmail\.com'\],.*
-dkutils/datakitchen_api/kitchen.py,193,.*'Developer': \['developer1@gmail\.com', 'developer2@gmail\.com'\],.*
-dkutils/datakitchen_api/kitchen.py,202,.*Retrieve the set of staff usernames assigned to this kitchen\..*
-dkutils/datakitchen_api/kitchen.py,217,.*set of current kitchen staff usernames of the form::.*
-dkutils/datakitchen_api/kitchen.py,220,.*'admin@gmail\.com',.*
-dkutils/datakitchen_api/kitchen.py,221,.*'developer1@gmail\.com',.*
-dkutils/datakitchen_api/kitchen.py,222,.*'developer2@gmail\.com',.*
-dkutils/datakitchen_api/kitchen.py,231,.*Ensure the user in the provided client has Admin privileges in this kitchen\. Otherwise,.*
-dkutils/datakitchen_api/kitchen.py,237,.*Dictionary keyed by role and valued by list of associated usernames\..*
-dkutils/datakitchen_api/kitchen.py,246,.*If the client user is not an Admin in this kitchen\..*
-dkutils/datakitchen_api/kitchen.py,286,.*'Start': \['foo@gmail\.com'\],.*
-dkutils/datakitchen_api/kitchen.py,288,.*'OverDuration': \['foo@gmail\.com', 'bar@gmail\.com'\],.*
-dkutils/datakitchen_api/kitchen.py,290,.*'Failure': \['foo@gmail\.com'\],.*
-dkutils/datakitchen_api/kitchen.py,312,.*'Start': \['foo@gmail\.com'\],.*
-dkutils/datakitchen_api/kitchen.py,314,.*'OverDuration': \['foo@gmail\.com', 'bar@gmail\.com'\],.*
-dkutils/datakitchen_api/kitchen.py,316,.*'Failure': \['foo@gmail\.com'\],.*
-dkutils/datakitchen_api/kitchen.py,354,.*'Start': \['foo@gmail\.com'\],.*
-dkutils/datakitchen_api/kitchen.py,356,.*'OverDuration': \['foo@gmail\.com', 'bar@gmail\.com'\],.*
-dkutils/datakitchen_api/kitchen.py,358,.*'Failure': \['foo@gmail\.com'\],.*
-dkutils/datakitchen_api/kitchen.py,395,.*If the current user is not an Admin.*
-dkutils/datakitchen_api/kitchen.py,403,.*'Admin': \['admin@gmail\.com'\],.*
-dkutils/datakitchen_api/kitchen.py,404,.*'Developer': \['developer1@gmail\.com', 'developer2@gmail\.com'\],.*
-dkutils/datakitchen_api/kitchen.py,416,.*List or set of usernames to delete from this kitchen's staff\..*
-dkutils/datakitchen_api/kitchen.py,423,.*If the current user is not an Admin.*
-dkutils/datakitchen_api/kitchen.py,453,.*Dictionary keyed by role and valued with list of users to add to that role in the form::.*
-dkutils/datakitchen_api/kitchen.py,456,.*'Admin': \['admin@gmail\.com'\],.*
-dkutils/datakitchen_api/kitchen.py,457,.*'Developer': \['developer1@gmail\.com', 'developer2@gmail\.com'\],.*
-dkutils/datakitchen_api/kitchen.py,465,.*If the current user is not an Admin.*
-dkutils/datakitchen_api/kitchen.py,507,.*Dictionary keyed by role and valued with list of users to update to that role in the form::.*
-dkutils/datakitchen_api/kitchen.py,510,.*'Admin': \['admin@gmail\.com'\],.*
-dkutils/datakitchen_api/kitchen.py,511,.*'Developer': \['developer1@gmail\.com', 'developer2@gmail\.com'\],.*
-dkutils/datakitchen_api/kitchen.py,519,.*If the current user is not an Admin.*
 dkutils/datakitchen_api/vault.py,59,.*'url': 'https://vault2\.datakitchen\.io:8200'.*
 dkutils/datakitchen_api/vault.py,84,.*Vault URL \(default: https://vault2\.datakitchen\.io:8200\)\..*
 dkutils/decorators.py,16,.*original from: http://wiki\.python\.org/moin/PythonDecoratorLibrary#Retry.*
-dkutils/datakitchen_api/order_run_monitor.py,26,.*DEFAULT_HOST = 'https://dev-api\.datakitchen\.io'.*
-dkutils/datakitchen_api/order_run_monitor.py,42,.*ALLOWED_TEST_STATUS_TYPES = \['PASSED', 'FAILED', 'WARNING'\].*
-dkutils/datakitchen_api/order_run_monitor.py,220,.*URL of the Events Ingestion API \(default: https://dev-api\.datakitchen\.io'\)\..*
+dkutils/datakitchen_api/kitchen.py,199,.*'Admin': \['admin@gmail\.com'\],.*
+dkutils/datakitchen_api/kitchen.py,200,.*'Developer': \['developer1@gmail\.com', 'developer2@gmail\.com'\],.*
+dkutils/datakitchen_api/kitchen.py,209,.*Retrieve the set of staff usernames assigned to this kitchen\..*
+dkutils/datakitchen_api/kitchen.py,224,.*set of current kitchen staff usernames of the form::.*
+dkutils/datakitchen_api/kitchen.py,227,.*'admin@gmail\.com',.*
+dkutils/datakitchen_api/kitchen.py,228,.*'developer1@gmail\.com',.*
+dkutils/datakitchen_api/kitchen.py,229,.*'developer2@gmail\.com',.*
+dkutils/datakitchen_api/kitchen.py,238,.*Ensure the user in the provided client has Admin privileges in this kitchen\. Otherwise,.*
+dkutils/datakitchen_api/kitchen.py,244,.*Dictionary keyed by role and valued by list of associated usernames\..*
+dkutils/datakitchen_api/kitchen.py,253,.*If the client user is not an Admin in this kitchen\..*
+dkutils/datakitchen_api/kitchen.py,293,.*'Start': \['foo@gmail\.com'\],.*
+dkutils/datakitchen_api/kitchen.py,295,.*'OverDuration': \['foo@gmail\.com', 'bar@gmail\.com'\],.*
+dkutils/datakitchen_api/kitchen.py,297,.*'Failure': \['foo@gmail\.com'\],.*
+dkutils/datakitchen_api/kitchen.py,319,.*'Start': \['foo@gmail\.com'\],.*
+dkutils/datakitchen_api/kitchen.py,321,.*'OverDuration': \['foo@gmail\.com', 'bar@gmail\.com'\],.*
+dkutils/datakitchen_api/kitchen.py,323,.*'Failure': \['foo@gmail\.com'\],.*
+dkutils/datakitchen_api/kitchen.py,361,.*'Start': \['foo@gmail\.com'\],.*
+dkutils/datakitchen_api/kitchen.py,363,.*'OverDuration': \['foo@gmail\.com', 'bar@gmail\.com'\],.*
+dkutils/datakitchen_api/kitchen.py,365,.*'Failure': \['foo@gmail\.com'\],.*
+dkutils/datakitchen_api/kitchen.py,402,.*If the current user is not an Admin.*
+dkutils/datakitchen_api/kitchen.py,410,.*'Admin': \['admin@gmail\.com'\],.*
+dkutils/datakitchen_api/kitchen.py,411,.*'Developer': \['developer1@gmail\.com', 'developer2@gmail\.com'\],.*
+dkutils/datakitchen_api/kitchen.py,423,.*List or set of usernames to delete from this kitchen's staff\..*
+dkutils/datakitchen_api/kitchen.py,430,.*If the current user is not an Admin.*
+dkutils/datakitchen_api/kitchen.py,460,.*Dictionary keyed by role and valued with list of users to add to that role in the form::.*
+dkutils/datakitchen_api/kitchen.py,463,.*'Admin': \['admin@gmail\.com'\],.*
+dkutils/datakitchen_api/kitchen.py,464,.*'Developer': \['developer1@gmail\.com', 'developer2@gmail\.com'\],.*
+dkutils/datakitchen_api/kitchen.py,472,.*If the current user is not an Admin.*
+dkutils/datakitchen_api/kitchen.py,514,.*Dictionary keyed by role and valued with list of users to update to that role in the form::.*
+dkutils/datakitchen_api/kitchen.py,517,.*'Admin': \['admin@gmail\.com'\],.*
+dkutils/datakitchen_api/kitchen.py,518,.*'Developer': \['developer1@gmail\.com', 'developer2@gmail\.com'\],.*
+dkutils/datakitchen_api/kitchen.py,526,.*If the current user is not an Admin.*
+dkutils/datakitchen_api/order_run_monitor.py,28,.*DEFAULT_HOST = 'https://dev-api\.datakitchen\.io'.*
+dkutils/datakitchen_api/order_run_monitor.py,44,.*ALLOWED_TEST_STATUS_TYPES = \['PASSED', 'FAILED', 'WARNING'\].*
+dkutils/datakitchen_api/order_run_monitor.py,50,.*user_info = dk_client\._api_request\(API_GET, 'userinfo'\).*
+dkutils/datakitchen_api/order_run_monitor.py,248,.*URL of the Events Ingestion API \(default: https://dev-api\.datakitchen\.io'\)\..*
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dataclasses==0.6
-events_ingestion_client==0.0.6
+events_ingestion_client==0.0.8
 jira==2.0.0
 pandas==1.1.2
 paramiko==2.10.4

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
     python_requires='>=3.8',
     install_requires=[
         "dataclasses>=0.6",
-        "events_ingestion_client>=0.0.6",
+        "events_ingestion_client>=0.0.8",
         "jira>=2.0.0",
         "pandas>=1.1.2",
         "paramiko>=2.10.4",


### PR DESCRIPTION
- Add order run external url to published events in the order run monitor
- Order Run Monitor now handles ingredients by replacing the ingredient kitchen name in the pipeline_name with the parent kitchen name to associate events with the parent order run.
- Update dependency events_ingestion_client to v0.0.8