### PR TITLE
PD-1210: Lock events ingestion client version

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,10 @@
 Release Notes
 =============
 
+v2.11.4
+-------
+* Lock events-ingestion-client dependency to v1.x
+
 v2.11.3
 -------
 * Update events-ingestion-client dependency to v1.0.0

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
     python_requires='>=3.8',
     install_requires=[
         "dataclasses>=0.6",
-        "events_ingestion_client>=1.0.0",
+        "events_ingestion_client~=1.0",
         "jira>=2.0.0",
         "pandas>=1.1.2",
         "paramiko>=2.10.4",


### PR DESCRIPTION
[PD-1210](https://datakitchen.atlassian.net/browse/PD-1210)

The version is locked to avoid automatically updating to a backward incompatible version of the lib.

Preparing a new release of DKUtils at the same time.